### PR TITLE
Fix numpy deprecated int

### DIFF
--- a/omega_format/visualization/modules/objects.py
+++ b/omega_format/visualization/modules/objects.py
@@ -87,7 +87,7 @@ class VisualizeTPPath(VisualizationModule):
         objects = {k: v for k, v in snip.reference.road_users.items()}
         objects[snip.reference.ego_id] = snip.reference.ego_vehicle
 
-        comet_tail_length = np.int(self.comet_tail_length_in_s * visualizer.fps)
+        comet_tail_length = int(self.comet_tail_length_in_s * visualizer.fps)
 
         for id_, tp in objects.items():
             if hasattr(tp, 'in_timespan') and tp.in_timespan(timestamp, timestamp, ):

--- a/omega_format/visualization/modules/perc_objects.py
+++ b/omega_format/visualization/modules/perc_objects.py
@@ -66,7 +66,7 @@ class VisualizePercPath(VisualizationModule):
         Visualizes the full paths of the objects
         """
         items = []
-        comet_tail_length = np.int(self.comet_tail_length_in_s * visualizer.fps)
+        comet_tail_length = int(self.comet_tail_length_in_s * visualizer.fps)
 
         for id_, obj in snip.perception.objects.items():
             if obj.in_timespan(timestamp, timestamp):


### PR DESCRIPTION
Running the visualization after a checking out the repository returns the following error with numpy:

```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is 
safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

Changing `np.int` to `int` as recommended fixes the error.